### PR TITLE
feat: 原始数据模式下隐藏自动分段配置并禁用手动分段按钮

### DIFF
--- a/src/components/RoomCard.vue
+++ b/src/components/RoomCard.vue
@@ -80,18 +80,18 @@
         </n-popover>
         <n-popover>
           <template #trigger>
-            <n-button quaternary size="small" :disabled="props.room.recordModeForThisSession === 1" @click="splitRecord">
+            <n-button quaternary size="small" :disabled="isRawMode" @click="splitRecord">
               <n-icon :component="CutSharp" />
             </n-button>
           </template>
-          <span>{{ props.room.recordModeForThisSession === 1 ? '原始数据模式禁用手动分段' : '手动分段' }}</span>
+          <span>{{ isRawMode ? '原始数据模式禁用手动分段' : '手动分段' }}</span>
         </n-popover>
       </div>
     </div>
   </n-card>
 </template>
 <script lang="ts">
-import { Component, h, onMounted, onUnmounted, PropType, ref, watch } from 'vue';
+import { Component, computed, h, onMounted, onUnmounted, PropType, ref, watch } from 'vue';
 import {
   DropdownOption, useMessage, NCard, NH3, NIcon,
   NSpace, NTooltip, NDropdown, NButton, NSkeleton, useThemeVars, NPopover,
@@ -252,6 +252,10 @@ const props = defineProps({
     default: false,
   },
 });
+
+const isRawMode = computed(() =>
+  (props.room.recordModeForThisSession ?? props.room.recordMode) === 1
+);
 
 const emit = defineEmits(['start-record', 'stop-record', 'refresh-room-info', 'start-auto-record',
   'stop-auto-record', 'delete', 'self-update', 'show-stats', 'room-setting']);

--- a/src/components/RoomCard.vue
+++ b/src/components/RoomCard.vue
@@ -80,11 +80,11 @@
         </n-popover>
         <n-popover>
           <template #trigger>
-            <n-button quaternary size="small" @click="splitRecord">
+            <n-button quaternary size="small" :disabled="props.room.recordMode === 1" @click="splitRecord">
               <n-icon :component="CutSharp" />
             </n-button>
           </template>
-          <span>手动分段</span>
+          <span>{{ props.room.recordMode === 1 ? '原始数据模式禁用手动分段' : '手动分段' }}</span>
         </n-popover>
       </div>
     </div>
@@ -196,6 +196,7 @@ const props = defineProps({
       'objectId': '00000000-0000-0000-0000-000000000000',
       'roomId': 0,
       'autoRecord': false,
+      'recordMode': 0,
       'shortId': 0,
       'name': '用户昵称',
       'title': '直播间标题',

--- a/src/components/RoomCard.vue
+++ b/src/components/RoomCard.vue
@@ -80,11 +80,11 @@
         </n-popover>
         <n-popover>
           <template #trigger>
-            <n-button quaternary size="small" :disabled="props.room.recordMode === 1" @click="splitRecord">
+            <n-button quaternary size="small" :disabled="props.room.recordModeForThisSession === 1" @click="splitRecord">
               <n-icon :component="CutSharp" />
             </n-button>
           </template>
-          <span>{{ props.room.recordMode === 1 ? '原始数据模式禁用手动分段' : '手动分段' }}</span>
+          <span>{{ props.room.recordModeForThisSession === 1 ? '原始数据模式禁用手动分段' : '手动分段' }}</span>
         </n-popover>
       </div>
     </div>
@@ -197,6 +197,7 @@ const props = defineProps({
       'roomId': 0,
       'autoRecord': false,
       'recordMode': 0,
+      'recordModeForThisSession': 0,
       'shortId': 0,
       'name': '用户昵称',
       'title': '直播间标题',

--- a/src/components/RoomSettingModal.vue
+++ b/src/components/RoomSettingModal.vue
@@ -25,21 +25,24 @@
             v-model:value="newRoomConfig['optionalFlvProcessorDisableSplitOnH264AnnexB']" :same-as-default="true" />
         </n-collapse-transition>
       </div>
-      <n-collapse-transition :show="globalConfig.recordMode === 0">
-        <div id="auto-split" class="setting-box">
-          <n-h3>自动分段</n-h3>
-          <optional-input type="enum" v-model:value="newRoomConfig['optionalCuttingMode']" :enums="CuttingModes" />
-          <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 1">
-            <optional-input type="number" prefix="每" suffix="保存为一个文件"
-              v-model:value="newRoomConfig['optionalCuttingNumber']" unit="分" max-input-width="150px" />
-          </n-collapse-transition>
-          <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 2">
-            <optional-input type="number" prefix="每" suffix="保存为一个文件"
-              v-model:value="newRoomConfig['optionalCuttingNumber']" unit="MiB" max-input-width="150px" />
-          </n-collapse-transition>
-          <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newRoomConfig['optionalCuttingByTitle']" />
-        </div>
-      </n-collapse-transition>
+      <div id="auto-split" class="setting-box">
+        <n-h3>自动分段</n-h3>
+        <n-collapse-transition :show="newRoomConfig['optionalRecordMode']?.value == 1">
+          <n-alert type="warning" title="提示" style="margin-bottom: 1em;">
+            原始数据模式下自动分段功能不可用
+          </n-alert>
+        </n-collapse-transition>
+        <optional-input type="enum" v-model:value="newRoomConfig['optionalCuttingMode']" :enums="CuttingModes" />
+        <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 1">
+          <optional-input type="number" prefix="每" suffix="保存为一个文件"
+            v-model:value="newRoomConfig['optionalCuttingNumber']" unit="分" max-input-width="150px" />
+        </n-collapse-transition>
+        <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 2">
+          <optional-input type="number" prefix="每" suffix="保存为一个文件"
+            v-model:value="newRoomConfig['optionalCuttingNumber']" unit="MiB" max-input-width="150px" />
+        </n-collapse-transition>
+        <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newRoomConfig['optionalCuttingByTitle']" />
+      </div>
       <div id="record-condition" class="setting-box">
         <p>直播间标题过滤 </p>
         <p>跳过录制的直播标题正则匹配表达式，每行一个</p>
@@ -75,9 +78,9 @@
   </n-modal>
 </template>
 <script lang="ts">
-import { computed, ref, watch } from 'vue';
+import { ref, watch } from 'vue';
 import {
-  useLoadingBar, useMessage, NCollapseTransition, NH3,
+  useLoadingBar, useMessage, NAlert, NCollapseTransition, NH3,
   NSpace, NButton, NModal, NSkeleton,
 } from 'naive-ui';
 import OptionalInput from './OptionalInput.vue';
@@ -138,10 +141,6 @@ watch(() => props.show, function (newVal, oldValue) {
 
 const newRoomConfig = ref<{ [key: string]: ConfigItem }>({});
 
-const globalConfig = computed(() => ({
-  recordMode: newRoomConfig.value['optionalRecordMode']?.value ?? 0,
-}));
-
 interface ConfigItem<T = any> {
   hasValue: boolean,
   value: T,
@@ -164,7 +163,7 @@ async function initSetting() {
     duration: 0,
   });
   let defaultConfig: { [key: string]: Optional<any> } = Recorder.getMockDefaultConfig() as any;
-  let globalConfigDto: { [key: string]: Optional<any> } = Recorder.getMockGlobalConfig() as any;
+  let globalConfig: { [key: string]: Optional<any> } = Recorder.getMockGlobalConfig() as any;
   let roomConfig: { [key: string]: Optional<any> };
   try {
     defaultConfig = await recorderController.recorder.getDefaultConfig() as any;
@@ -173,7 +172,7 @@ async function initSetting() {
     message.error('获取默认配置失败，部分设置可能与实际不符');
   }
   try {
-    globalConfigDto = await recorderController.recorder.getGlobalConfig() as any;
+    globalConfig = await recorderController.recorder.getGlobalConfig() as any;
   } catch (error: any) {
     message.error(error?.message || error.toString());
     message.error('获取全局配置失败，部分设置可能与实际不符');
@@ -186,8 +185,8 @@ async function initSetting() {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
         hasValue: roomConfig[key].hasValue,
-        value: roomConfig[key].hasValue ? roomConfig[key].value : (globalConfigDto[key]?.hasValue ? globalConfigDto[key].value : defaultConfig[rawkey]),
-        defaultValue: (globalConfigDto[key]?.hasValue ? globalConfigDto[key].value : defaultConfig[rawkey]),
+        value: roomConfig[key].hasValue ? roomConfig[key].value : (globalConfig[key]?.hasValue ? globalConfig[key].value : defaultConfig[rawkey]),
+        defaultValue: (globalConfig[key]?.hasValue ? globalConfig[key].value : defaultConfig[rawkey]),
       };
     });
     temp['autoRecord'] = {

--- a/src/components/RoomSettingModal.vue
+++ b/src/components/RoomSettingModal.vue
@@ -163,7 +163,7 @@ async function initSetting() {
     duration: 0,
   });
   let defaultConfig: { [key: string]: Optional<any> } = Recorder.getMockDefaultConfig() as any;
-  let globalConfig: { [key: string]: Optional<any> } = Recorder.getMockGlobalConfig() as any;
+  let globalConfigDto: { [key: string]: Optional<any> } = Recorder.getMockGlobalConfig() as any;
   let roomConfig: { [key: string]: Optional<any> };
   try {
     defaultConfig = await recorderController.recorder.getDefaultConfig() as any;
@@ -172,7 +172,7 @@ async function initSetting() {
     message.error('获取默认配置失败，部分设置可能与实际不符');
   }
   try {
-    globalConfig = await recorderController.recorder.getGlobalConfig() as any;
+    globalConfigDto = await recorderController.recorder.getGlobalConfig() as any;
   } catch (error: any) {
     message.error(error?.message || error.toString());
     message.error('获取全局配置失败，部分设置可能与实际不符');
@@ -185,8 +185,8 @@ async function initSetting() {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
         hasValue: roomConfig[key].hasValue,
-        value: roomConfig[key].hasValue ? roomConfig[key].value : (globalConfig[key]?.hasValue ? globalConfig[key].value : defaultConfig[rawkey]),
-        defaultValue: (globalConfig[key]?.hasValue ? globalConfig[key].value : defaultConfig[rawkey]),
+        value: roomConfig[key].hasValue ? roomConfig[key].value : (globalConfigDto[key]?.hasValue ? globalConfigDto[key].value : defaultConfig[rawkey]),
+        defaultValue: (globalConfigDto[key]?.hasValue ? globalConfigDto[key].value : defaultConfig[rawkey]),
       };
     });
     temp['autoRecord'] = {

--- a/src/components/RoomSettingModal.vue
+++ b/src/components/RoomSettingModal.vue
@@ -25,19 +25,21 @@
             v-model:value="newRoomConfig['optionalFlvProcessorDisableSplitOnH264AnnexB']" :same-as-default="true" />
         </n-collapse-transition>
       </div>
-      <div id="auto-split" class="setting-box">
-        <n-h3>自动分段</n-h3>
-        <optional-input type="enum" v-model:value="newRoomConfig['optionalCuttingMode']" :enums="CuttingModes" />
-        <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 1">
-          <optional-input type="number" prefix="每" suffix="保存为一个文件"
-            v-model:value="newRoomConfig['optionalCuttingNumber']" unit="分" max-input-width="150px" />
-        </n-collapse-transition>
-        <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 2">
-          <optional-input type="number" prefix="每" suffix="保存为一个文件"
-            v-model:value="newRoomConfig['optionalCuttingNumber']" unit="MiB" max-input-width="150px" />
-        </n-collapse-transition>
-        <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newRoomConfig['optionalCuttingByTitle']" />
-      </div>
+      <n-collapse-transition :show="globalConfig.recordMode === 0">
+        <div id="auto-split" class="setting-box">
+          <n-h3>自动分段</n-h3>
+          <optional-input type="enum" v-model:value="newRoomConfig['optionalCuttingMode']" :enums="CuttingModes" />
+          <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 1">
+            <optional-input type="number" prefix="每" suffix="保存为一个文件"
+              v-model:value="newRoomConfig['optionalCuttingNumber']" unit="分" max-input-width="150px" />
+          </n-collapse-transition>
+          <n-collapse-transition :show="newRoomConfig['optionalCuttingMode'].value == 2">
+            <optional-input type="number" prefix="每" suffix="保存为一个文件"
+              v-model:value="newRoomConfig['optionalCuttingNumber']" unit="MiB" max-input-width="150px" />
+          </n-collapse-transition>
+          <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newRoomConfig['optionalCuttingByTitle']" />
+        </div>
+      </n-collapse-transition>
       <div id="record-condition" class="setting-box">
         <p>直播间标题过滤 </p>
         <p>跳过录制的直播标题正则匹配表达式，每行一个</p>
@@ -73,7 +75,7 @@
   </n-modal>
 </template>
 <script lang="ts">
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import {
   useLoadingBar, useMessage, NCollapseTransition, NH3,
   NSpace, NButton, NModal, NSkeleton,
@@ -136,6 +138,10 @@ watch(() => props.show, function (newVal, oldValue) {
 
 const newRoomConfig = ref<{ [key: string]: ConfigItem }>({});
 
+const globalConfig = computed(() => ({
+  recordMode: newRoomConfig.value['optionalRecordMode']?.value ?? 0,
+}));
+
 interface ConfigItem<T = any> {
   hasValue: boolean,
   value: T,
@@ -158,7 +164,7 @@ async function initSetting() {
     duration: 0,
   });
   let defaultConfig: { [key: string]: Optional<any> } = Recorder.getMockDefaultConfig() as any;
-  let globalConfig: { [key: string]: Optional<any> } = Recorder.getMockGlobalConfig() as any;
+  let globalConfigDto: { [key: string]: Optional<any> } = Recorder.getMockGlobalConfig() as any;
   let roomConfig: { [key: string]: Optional<any> };
   try {
     defaultConfig = await recorderController.recorder.getDefaultConfig() as any;
@@ -167,7 +173,7 @@ async function initSetting() {
     message.error('获取默认配置失败，部分设置可能与实际不符');
   }
   try {
-    globalConfig = await recorderController.recorder.getGlobalConfig() as any;
+    globalConfigDto = await recorderController.recorder.getGlobalConfig() as any;
   } catch (error: any) {
     message.error(error?.message || error.toString());
     message.error('获取全局配置失败，部分设置可能与实际不符');
@@ -180,8 +186,8 @@ async function initSetting() {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
         hasValue: roomConfig[key].hasValue,
-        value: roomConfig[key].hasValue ? roomConfig[key].value : (globalConfig[key]?.hasValue ? globalConfig[key].value : defaultConfig[rawkey]),
-        defaultValue: (globalConfig[key]?.hasValue ? globalConfig[key].value : defaultConfig[rawkey]),
+        value: roomConfig[key].hasValue ? roomConfig[key].value : (globalConfigDto[key]?.hasValue ? globalConfigDto[key].value : defaultConfig[rawkey]),
+        defaultValue: (globalConfigDto[key]?.hasValue ? globalConfigDto[key].value : defaultConfig[rawkey]),
       };
     });
     temp['autoRecord'] = {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -202,6 +202,7 @@ export interface RoomDto {
   objectId: string;
   roomId: number;
   autoRecord: boolean;
+  recordMode: RecordMode;
   shortId: number;
   name: string;
   title: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -203,6 +203,7 @@ export interface RoomDto {
   roomId: number;
   autoRecord: boolean;
   recordMode: RecordMode;
+  recordModeForThisSession: RecordMode;
   shortId: number;
   name: string;
   title: string;

--- a/src/views/recorder/SettingPage.vue
+++ b/src/views/recorder/SettingPage.vue
@@ -49,23 +49,26 @@
             @changed="onChanged" />
         </n-collapse-transition>
       </div>
-      <n-collapse-transition :show="globalConfig.recordMode === 0">
-        <div id="auto-split" class="setting-box">
-          <n-h3>自动分段</n-h3>
-          <optional-input type="enum" label="分段模式" v-model:value="newConfig['optionalCuttingMode']" :enums="CuttingModes"
-            :same-as-default="true" @changed="onChanged" />
-          <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 1">
-            <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
-              :same-as-default="true" unit="分" max-input-width="150px" @changed="onChanged" />
-          </n-collapse-transition>
-          <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 2">
-            <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
-              :same-as-default="true" unit="MiB" max-input-width="150px" @changed="onChanged" />
-          </n-collapse-transition>
-          <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newConfig['optionalCuttingByTitle']"
-            :same-as-default="true" @changed="onChanged" />
-        </div>
-      </n-collapse-transition>
+      <div id="auto-split" class="setting-box">
+        <n-h3>自动分段</n-h3>
+        <n-collapse-transition :show="newConfig['optionalRecordMode']?.value == 1">
+          <n-alert type="warning" title="提示" style="margin-bottom: 1em;">
+            原始数据模式下自动分段功能不可用
+          </n-alert>
+        </n-collapse-transition>
+        <optional-input type="enum" label="分段模式" v-model:value="newConfig['optionalCuttingMode']" :enums="CuttingModes"
+          :same-as-default="true" @changed="onChanged" />
+        <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 1">
+          <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
+            :same-as-default="true" unit="分" max-input-width="150px" @changed="onChanged" />
+        </n-collapse-transition>
+        <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 2">
+          <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
+            :same-as-default="true" unit="MiB" max-input-width="150px" @changed="onChanged" />
+        </n-collapse-transition>
+        <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newConfig['optionalCuttingByTitle']"
+          :same-as-default="true" @changed="onChanged" />
+      </div>
       <div id="record-condition" class="setting-box">
         <n-h3>录制条件</n-h3>
         <p>直播间标题过滤 </p>
@@ -174,8 +177,7 @@
         :internalScrollable="false" style="position:sticky; top:64px;">
         <n-anchor-link title="弹幕录制" href="#danmaku-record" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="录制模式" href="#record-mode" @click="(e: any) => { e.preventDefault() }" />
-        <n-anchor-link v-if="globalConfig.recordMode === 0" title="自动分段" href="#auto-split"
-          @click="(e: any) => { e.preventDefault() }" />
+        <n-anchor-link title="自动分段" href="#auto-split" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="录制条件" href="#record-condition" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="文件写入" href="#storage" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="录制画质" href="#record-quality" @click="(e: any) => { e.preventDefault() }" />
@@ -197,7 +199,7 @@
 
 <script setup lang="ts">
 import { NH2, NH3, NCollapseTransition, NAnchor, NAnchorLink, NSpace, NSwitch, NA, NAlert, NButton, NAffix, NCard, useLoadingBar, useMessage } from 'naive-ui';
-import { computed, onMounted, ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import { Recorder, Optional } from '../../utils/api';
 import OptionalInput from '../../components/OptionalInput.vue';
 import { recorderController } from '../../utils/RecorderController';
@@ -321,10 +323,6 @@ const newConfig = ref<{ [key: string]: ConfigItem }>({
   'optionalTitleFilterPatterns': getEmptyConfigItem(defaultConfig.value.titleFilterPatterns),
 });
 
-const globalConfig = computed(() => ({
-  recordMode: newConfig.value['optionalRecordMode']?.value ?? defaultConfig.value.recordMode,
-}));
-
 let lastload: string | undefined = '';
 
 async function init(): Promise<void> {
@@ -351,14 +349,14 @@ async function init(): Promise<void> {
     }
   }
   try {
-    const globalConfigDto = (await recorderController.recorder.getGlobalConfig()) as unknown as { [key: string]: Optional<any> };
-    const keys = Object.keys(globalConfigDto);
+    const globalConfig = (await recorderController.recorder.getGlobalConfig()) as unknown as { [key: string]: Optional<any> };
+    const keys = Object.keys(globalConfig);
     const temp: any = {};
     keys.forEach((key) => {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
-        hasValue: globalConfigDto[key].hasValue,
-        value: globalConfigDto[key].hasValue ? globalConfigDto[key].value : defaultConfig.value[rawkey],
+        hasValue: globalConfig[key].hasValue,
+        value: globalConfig[key].hasValue ? globalConfig[key].value : defaultConfig.value[rawkey],
         defaultValue: defaultConfig.value[rawkey],
       };
     });
@@ -389,14 +387,14 @@ async function saveConfig() {
     duration: 0,
   });
   try {
-    const globalConfigDto = (await recorderController.recorder.setGlobalConfig(newConfig.value)) as unknown as { [key: string]: Optional<any> };
-    const keys = Object.keys(globalConfigDto);
+    const globalConfig = (await recorderController.recorder.setGlobalConfig(newConfig.value)) as unknown as { [key: string]: Optional<any> };
+    const keys = Object.keys(globalConfig);
     const temp: any = {};
     keys.forEach((key) => {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
-        hasValue: globalConfigDto[key].hasValue,
-        value: globalConfigDto[key].hasValue ? globalConfigDto[key].value : defaultConfig.value[rawkey],
+        hasValue: globalConfig[key].hasValue,
+        value: globalConfig[key].hasValue ? globalConfig[key].value : defaultConfig.value[rawkey],
         defaultValue: defaultConfig.value[rawkey],
       };
     });

--- a/src/views/recorder/SettingPage.vue
+++ b/src/views/recorder/SettingPage.vue
@@ -49,21 +49,23 @@
             @changed="onChanged" />
         </n-collapse-transition>
       </div>
-      <div id="auto-split" class="setting-box">
-        <n-h3>自动分段</n-h3>
-        <optional-input type="enum" label="分段模式" v-model:value="newConfig['optionalCuttingMode']" :enums="CuttingModes"
-          :same-as-default="true" @changed="onChanged" />
-        <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 1">
-          <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
-            :same-as-default="true" unit="分" max-input-width="150px" @changed="onChanged" />
-        </n-collapse-transition>
-        <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 2">
-          <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
-            :same-as-default="true" unit="MiB" max-input-width="150px" @changed="onChanged" />
-        </n-collapse-transition>
-        <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newConfig['optionalCuttingByTitle']"
-          :same-as-default="true" @changed="onChanged" />
-      </div>
+      <n-collapse-transition :show="globalConfig.recordMode === 0">
+        <div id="auto-split" class="setting-box">
+          <n-h3>自动分段</n-h3>
+          <optional-input type="enum" label="分段模式" v-model:value="newConfig['optionalCuttingMode']" :enums="CuttingModes"
+            :same-as-default="true" @changed="onChanged" />
+          <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 1">
+            <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
+              :same-as-default="true" unit="分" max-input-width="150px" @changed="onChanged" />
+          </n-collapse-transition>
+          <n-collapse-transition :show="newConfig['optionalCuttingMode']?.value == 2">
+            <optional-input type="number" prefix="每" suffix="保存为一个文件" v-model:value="newConfig['optionalCuttingNumber']"
+              :same-as-default="true" unit="MiB" max-input-width="150px" @changed="onChanged" />
+          </n-collapse-transition>
+          <optional-input type="boolean" label="直播间标题修改时切分文件" v-model:value="newConfig['optionalCuttingByTitle']"
+            :same-as-default="true" @changed="onChanged" />
+        </div>
+      </n-collapse-transition>
       <div id="record-condition" class="setting-box">
         <n-h3>录制条件</n-h3>
         <p>直播间标题过滤 </p>
@@ -172,7 +174,8 @@
         :internalScrollable="false" style="position:sticky; top:64px;">
         <n-anchor-link title="弹幕录制" href="#danmaku-record" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="录制模式" href="#record-mode" @click="(e: any) => { e.preventDefault() }" />
-        <n-anchor-link title="自动分段" href="#auto-split" @click="(e: any) => { e.preventDefault() }" />
+        <n-anchor-link v-if="globalConfig.recordMode === 0" title="自动分段" href="#auto-split"
+          @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="录制条件" href="#record-condition" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="文件写入" href="#storage" @click="(e: any) => { e.preventDefault() }" />
         <n-anchor-link title="录制画质" href="#record-quality" @click="(e: any) => { e.preventDefault() }" />
@@ -194,7 +197,7 @@
 
 <script setup lang="ts">
 import { NH2, NH3, NCollapseTransition, NAnchor, NAnchorLink, NSpace, NSwitch, NA, NAlert, NButton, NAffix, NCard, useLoadingBar, useMessage } from 'naive-ui';
-import { onMounted, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { Recorder, Optional } from '../../utils/api';
 import OptionalInput from '../../components/OptionalInput.vue';
 import { recorderController } from '../../utils/RecorderController';
@@ -318,6 +321,10 @@ const newConfig = ref<{ [key: string]: ConfigItem }>({
   'optionalTitleFilterPatterns': getEmptyConfigItem(defaultConfig.value.titleFilterPatterns),
 });
 
+const globalConfig = computed(() => ({
+  recordMode: newConfig.value['optionalRecordMode']?.value ?? defaultConfig.value.recordMode,
+}));
+
 let lastload: string | undefined = '';
 
 async function init(): Promise<void> {
@@ -344,14 +351,14 @@ async function init(): Promise<void> {
     }
   }
   try {
-    const globalConfig = (await recorderController.recorder.getGlobalConfig()) as unknown as { [key: string]: Optional<any> };
-    const keys = Object.keys(globalConfig);
+    const globalConfigDto = (await recorderController.recorder.getGlobalConfig()) as unknown as { [key: string]: Optional<any> };
+    const keys = Object.keys(globalConfigDto);
     const temp: any = {};
     keys.forEach((key) => {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
-        hasValue: globalConfig[key].hasValue,
-        value: globalConfig[key].hasValue ? globalConfig[key].value : defaultConfig.value[rawkey],
+        hasValue: globalConfigDto[key].hasValue,
+        value: globalConfigDto[key].hasValue ? globalConfigDto[key].value : defaultConfig.value[rawkey],
         defaultValue: defaultConfig.value[rawkey],
       };
     });
@@ -382,14 +389,14 @@ async function saveConfig() {
     duration: 0,
   });
   try {
-    const globalConfig = (await recorderController.recorder.setGlobalConfig(newConfig.value)) as unknown as { [key: string]: Optional<any> };
-    const keys = Object.keys(globalConfig);
+    const globalConfigDto = (await recorderController.recorder.setGlobalConfig(newConfig.value)) as unknown as { [key: string]: Optional<any> };
+    const keys = Object.keys(globalConfigDto);
     const temp: any = {};
     keys.forEach((key) => {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
-        hasValue: globalConfig[key].hasValue,
-        value: globalConfig[key].hasValue ? globalConfig[key].value : defaultConfig.value[rawkey],
+        hasValue: globalConfigDto[key].hasValue,
+        value: globalConfigDto[key].hasValue ? globalConfigDto[key].value : defaultConfig.value[rawkey],
         defaultValue: defaultConfig.value[rawkey],
       };
     });

--- a/src/views/recorder/SettingPage.vue
+++ b/src/views/recorder/SettingPage.vue
@@ -349,14 +349,14 @@ async function init(): Promise<void> {
     }
   }
   try {
-    const globalConfig = (await recorderController.recorder.getGlobalConfig()) as unknown as { [key: string]: Optional<any> };
-    const keys = Object.keys(globalConfig);
+    const globalConfigDto = (await recorderController.recorder.getGlobalConfig()) as unknown as { [key: string]: Optional<any> };
+    const keys = Object.keys(globalConfigDto);
     const temp: any = {};
     keys.forEach((key) => {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
-        hasValue: globalConfig[key].hasValue,
-        value: globalConfig[key].hasValue ? globalConfig[key].value : defaultConfig.value[rawkey],
+        hasValue: globalConfigDto[key].hasValue,
+        value: globalConfigDto[key].hasValue ? globalConfigDto[key].value : defaultConfig.value[rawkey],
         defaultValue: defaultConfig.value[rawkey],
       };
     });
@@ -387,14 +387,14 @@ async function saveConfig() {
     duration: 0,
   });
   try {
-    const globalConfig = (await recorderController.recorder.setGlobalConfig(newConfig.value)) as unknown as { [key: string]: Optional<any> };
-    const keys = Object.keys(globalConfig);
+    const globalConfigDto = (await recorderController.recorder.setGlobalConfig(newConfig.value)) as unknown as { [key: string]: Optional<any> };
+    const keys = Object.keys(globalConfigDto);
     const temp: any = {};
     keys.forEach((key) => {
       const rawkey = key.substring(8, 9).toLowerCase() + key.substring(9);
       temp[key] = {
-        hasValue: globalConfig[key].hasValue,
-        value: globalConfig[key].hasValue ? globalConfig[key].value : defaultConfig.value[rawkey],
+        hasValue: globalConfigDto[key].hasValue,
+        value: globalConfigDto[key].hasValue ? globalConfigDto[key].value : defaultConfig.value[rawkey],
         defaultValue: defaultConfig.value[rawkey],
       };
     });


### PR DESCRIPTION
## 功能说明
- 原始数据模式下，自动分段功能无效，因此隐藏相关 UI 配置
- 原始数据模式下，手动分段功能无效，因此禁用按钮并显示提示

## 改动内容
- 全局设置页和单房间设置页：原始数据模式下隐藏自动分段配置区块
- 房间卡片：原始数据模式下禁用手动分段按钮
- 添加动态 tooltip 提示：原始数据模式下显示"原始数据模式禁用手动分段"
- 更新 RoomDto 类型定义，添加 recordMode 字段

## 技术细节
- 使用 n-collapse-transition 实现条件渲染
- 使用 :disabled 属性禁用按钮
- 使用三元表达式动态显示 tooltip 内容

## 测试
- ✅ 原始数据模式下自动分段配置隐藏
- ✅ 原始数据模式下手动分段按钮禁用
- ✅ 鼠标悬停显示禁用原因提示
- ✅ 标准模式下所有功能正常

## 相关 PR
- 主仓库: BililiveRecorder/BililiveRecorder#763